### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,4 +1,7 @@
 name: Build Maven Project
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mn1598/tournament-planner/security/code-scanning/2](https://github.com/mn1598/tournament-planner/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for commenting on pull requests.

The `permissions` block should be added at the top level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
